### PR TITLE
Add psycopg module

### DIFF
--- a/{{cookiecutter.module_name}}/pyproject.toml
+++ b/{{cookiecutter.module_name}}/pyproject.toml
@@ -13,6 +13,7 @@ djangorestframework = "^3.11.0"
 markdown = "^3.2.2"
 django-filter = "^2.2.0"
 djangorestframework-simplejwt = {git = "https://github.com/SimpleJWT/django-rest-framework-simplejwt"}
+psycopg2-binary  = "^2.8.5"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"


### PR DESCRIPTION
Fix: ModuleNotFoundError: No module named 'psycopg2'
#24 