### PR TITLE
Feature/api documentation generator

### DIFF
--- a/{{cookiecutter.module_name}}/pyproject.toml
+++ b/{{cookiecutter.module_name}}/pyproject.toml
@@ -13,6 +13,7 @@ djangorestframework = "^3.11.0"
 markdown = "^3.2.2"
 django-filter = "^2.2.0"
 djangorestframework-simplejwt = {git = "https://github.com/SimpleJWT/django-rest-framework-simplejwt"}
+drf-yasg = "^1.17.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"

--- a/{{cookiecutter.module_name}}/settings.yaml
+++ b/{{cookiecutter.module_name}}/settings.yaml
@@ -20,6 +20,7 @@ default:
     - django.contrib.messages
     - django.contrib.staticfiles
     - rest_framework
+    - drf_yasg
     - {{cookiecutter.module_name}}.apps.user
     - {{cookiecutter.module_name}}.apps.rest_api
   MIDDLEWARE:

--- a/{{cookiecutter.module_name}}/{{cookiecutter.module_name}}/urls.py
+++ b/{{cookiecutter.module_name}}/{{cookiecutter.module_name}}/urls.py
@@ -16,11 +16,32 @@ Including another URLconf
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
-from django.urls import include, path
+from django.urls import include, path, re_path
+
+from rest_framework import permissions
+from drf_yasg.views import get_schema_view
+from drf_yasg import openapi
+
 
 from .apps.rest_api import router
 
+schema_view = get_schema_view(
+   openapi.Info(
+      title="{{cookiecutter.module_name}} API",
+      default_version='v1',
+      description="{{cookiecutter.description}}",
+      terms_of_service="https://www.google.com/policies/terms/",
+      contact=openapi.Contact(email="{{cookiecutter.email}}"),
+      license=openapi.License(name="BSD License"),
+   ),
+   public=True,
+   permission_classes=(permissions.AllowAny,),
+)
+
 urlpatterns = [
+    re_path(r'^swagger(?P<format>\.json|\.yaml)$', schema_view.without_ui(cache_timeout=0), name='schema-json'),
+    re_path(r'^swagger/$', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
+    re_path(r'^redoc/$', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
     path("api/v1/", include(router)),
     path("admin/", admin.site.urls),
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)


### PR DESCRIPTION
Add DRF_yasg on project #2 

DRF > 3.11 bronk the DRF_yasg:
Could not import 'drf_yasg.generators.OpenAPISchemaGenerator' for API setting 'DEFAULT_GENERATOR_CLASS'. ImportError: cannot import name 'URLPattern' from 'rest_framework.compat' (/usr/local/lib/python3.9/site-packages/rest_framework/compat.py).

The last DRF version remove the URLPattern, URLResolver and get_original_route that are used by drf-yasg.
`https://github.com/encode/django-rest-framework/commit/bb795674f86828fc5f15d6d61501cc781811e053`